### PR TITLE
remove check xml extension of file

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,6 @@ module.exports = function (options) {
 			return cb(new gutil.PluginError('gulp-xml2json', 'Streaming not supported'));
 		}
 
-		if (['.xml', '.XML'].indexOf(path.extname(file.path)) === -1) {
-			gutil.log('gulp-xml2json: Skipping unsupported xml ' + gutil.colors.blue(file.relative));
-			return cb(null, file);
-		}
-
 		tempWrite(file.contents, path.extname(file.path), function (err, tempFile) {
 			if (err) {
 				return cb(new gutil.PluginError('gulp-xml2json', err));

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (options) {
 					var parser = new xml2js.Parser(options);
 					parser.parseString(data, function (err, result) {
 						if(err) throw new Error(err);
-						gutil.log('gulp-xml2json:', gutil.colors.green('✔ ') + file.relative);
+						gutil.log('gulp-xml2json:', gutil.colors.green('ok ') + file.relative);
 						file.contents = new Buffer(JSON.stringify(result));
 						file.path = gutil.replaceExtension(file.path, '.json');
 						cb(null, file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-x2j",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "xml to json using gulp",
   "repository": "https://github.com/bmsdave/gulp-xml2json.git",
   "main": "index.js",
@@ -17,7 +17,7 @@
     "gulp-util": "~2.2.0",
     "graceful-fs": "~4.1.11",
     "filesize": "~2.0.0",
-    "temp-write": "~0.1.0",
+    "temp-write": "~3.3.0",
     "map-stream": "0.0.4",
     "xml2js": "~0.4.1",
     "gulp-rename": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-x2j",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "xml to json using gulp",
   "repository": "https://github.com/bmsdave/gulp-xml2json.git",
   "main": "index.js",
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "graceful-fs": "~2.0.0",
+    "graceful-fs": "~4.1.11",
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-x2j",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "xml to json using gulp",
   "repository": "https://github.com/bmsdave/gulp-xml2json.git",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "gulp-xml2json",
-  "version": "0.1.5",
+  "name": "gulp-x2j",
+  "version": "0.2.2",
   "description": "xml to json using gulp",
-  "repository": "https://github.com/DataGarage/gulp-xml2json",
+  "repository": "https://github.com/bmsdave/gulp-xml2json.git",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
@@ -22,9 +22,13 @@
     "xml2js": "~0.4.1",
     "gulp-rename": "~1.1.0"
   },
-  "author": "chilijung",
-  "license": "MIT",
   "devDependencies": {
     "mocha": "~1.17.1"
-  }
+  },
+  "author": "bmsdave@gmail.com",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bmsdave/gulp-xml2json/issues"
+  },
+  "homepage": "https://github.com/bmsdave/gulp-xml2json"
 }


### PR DESCRIPTION
Hi!

Please remove check of xml extension of file.
Data in XML format is not necessarily transmitted in files with extensions = "XML" or "xml".

I think that this test is a duplicate.
I can filter out the files you want by specifying the extension in gulp.src

Thank you for this plugin.
It helped me.
I hope this pull request will be useful!