### PR TITLE
provide option to clear tmp files

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ module.exports = function (options) {
 				options = options || {};
 
 				fs.readFile(tempFile, { encoding : 'UTF-8'}, function(err, data) {
+					if(option.removeTmpFiles) {
+					 	fs.unlinkSync(tempFile);
+					}
 					if (err) {
 						return cb(new gutil.PluginError('gulp-xml2json', err));
 					}


### PR DESCRIPTION
Currently "tmp files" are left in the tmp folder,   which consumes a lot of disk space.   